### PR TITLE
Command-line args for rows, columns and TDM/not-TDM status

### DIFF
--- a/datasubscriber.cpp
+++ b/datasubscriber.cpp
@@ -158,7 +158,7 @@ void dataSubscriber::process() {
         //           << pr->wordsize <<"-byte words: [";
         // std::cout << pr->data[0] <<", " << pr->data[1] << "... "
         //           << pr->data[pr->nsamples-1] <<"] dT="<< pr->sampletime << std::endl;
-        int tracenum = window->chan2trace(pr->channum);
+        int tracenum = window->streamnum2trace(pr->channum);
         if (tracenum >= 0) {
             if (pr->sampletime != sampletime) {
                 sampletime = pr->sampletime;

--- a/datasubscriber.cpp
+++ b/datasubscriber.cpp
@@ -98,7 +98,6 @@ void dataSubscriber::process() {
     try {
         killsocket->connect(KILLPORT);
         killsocket->setsockopt(ZMQ_SUBSCRIBE, "Quit", 4);
-        std::cout << "killsocket subscriber connected" << std::endl;
     } catch (zmq::error_t) {
         delete killsocket;
         killsocket = NULL;
@@ -109,7 +108,6 @@ void dataSubscriber::process() {
     try {
         chansocket->connect(CHANSUBPORT);
         chansocket->setsockopt(ZMQ_SUBSCRIBE, "", 0);
-        std::cout << "chansocket subscriber connected" << std::endl;
     } catch (zmq::error_t) {
         delete chansocket;
         chansocket = NULL;

--- a/datasubscriber.h
+++ b/datasubscriber.h
@@ -27,6 +27,9 @@ signals:
     /// Signal emitted when this object completes (i.e., its destructor is called)
     void finished(void);
 
+    /// Signal emitted when this object fails to run (e.g., cannot reach host)
+    void failed(void);
+
     void newSampleTime(double);
 
     /// Signal that a data vector is ready to plot

--- a/main.cpp
+++ b/main.cpp
@@ -32,13 +32,17 @@ options *processOptions(int argc, char *argv[])
         { "rows", required_argument, NULL, 'r'},
         { "columns", required_argument, NULL, 'c'},
         { "no-error-channel", no_argument, NULL, 'n'},
+        { "help", no_argument, NULL, 'h'},
         { NULL, 0, NULL, 0 }
     };
 
     int ch;
     QString name;
-    while ((ch = getopt_long(argc, argv, "na:r:c:", longopts, 0)) != -1) {
+    while ((ch = getopt_long(argc, argv, "hna:r:c:", longopts, 0)) != -1) {
         switch (ch) {
+        case 'h':
+            Opt->failed = true;
+            return Opt;
         case 'n':
             Opt->tdm = false;
             break;
@@ -65,8 +69,11 @@ options *processOptions(int argc, char *argv[])
 
 
 void usage() {
-    std::cerr << "Usage: microscope [--no-error-channel/-n] [--appname AppName/-a AppName]\n"
-                 "       -c8 -r28 tcp://localhost:5502" << std::endl;
+    std::cerr << "Usage: microscope [options] -c8 -r28 tcp://localhost:5502\n"
+              << "Options include:\n"
+              << "     -h, --help              Print this help message\n"
+              << "     -n, --no-error-channel  This is a non-TDM system and has no error channels\n"
+              << "     -a, --appname AppName   Change the app name on the window title bar\n" << std::endl;
 }
 
 

--- a/plotwindow.cpp
+++ b/plotwindow.cpp
@@ -553,12 +553,13 @@ void plotWindow::updateQuickTypeFromErr(int index)
     if (c1<1)
         return;
 
-    QString quicktext;
-    for (int i=0; i<NUM_TRACES && c1<=c2; i++) {
-        quicktext.append(QString("e%1,").arg(c1++));
+    for (int i=0; i<spinners.size() && c1<=c2; i++) {
+        spinners[i]->setValue(c1++);
     }
-    ui->quickChanEdit->setText(quicktext);
+    for (int i=0; i<checkers.size(); i++)
+        checkers[i]->setChecked(true);
     ui->quickFBComboBox->setCurrentIndex(0);
+    updateQuickTypeText();
 }
 
 
@@ -577,12 +578,13 @@ void plotWindow::updateQuickTypeFromFB(int index)
     if (c1<1)
         return;
 
-    QString quicktext;
-    for (int i=0; i<NUM_TRACES && c1<=c2; i++) {
-        quicktext.append(QString("%1,").arg(c1++));
+    for (int i=0; i<spinners.size() && c1<=c2; i++) {
+        spinners[i]->setValue(c1++);
     }
-    ui->quickChanEdit->setText(quicktext);
+    for (int i=0; i<checkers.size(); i++)
+        checkers[i]->setChecked(false);
     ui->quickErrComboBox->setCurrentIndex(0);
+    updateQuickTypeText();
 }
 
 
@@ -607,7 +609,9 @@ void plotWindow::updateQuickTypeText(void)
         }
     }
     text.chop(1); // remove trailing comma
-    ui->quickChanEdit->setPlainText(text);
+    QString existingText = ui->quickChanEdit->toPlainText();
+    if (text != existingText)
+        ui->quickChanEdit->setPlainText(text);
 }
 
 
@@ -656,8 +660,6 @@ void plotWindow::subscribeStream(int tracenum, int newStreamIndex) {
 ///
 void plotWindow::channelChanged(int newChan)
 {
-    ui->quickFBComboBox->setCurrentIndex(0);
-    ui->quickErrComboBox->setCurrentIndex(0);
     QSpinBox *box = static_cast<QSpinBox *>(sender());
     for (int i=0; i<spinners.size(); i++) {
         if (spinners[i] == box) {
@@ -669,7 +671,6 @@ void plotWindow::channelChanged(int newChan)
                     newStreamIndex++;
             }
             subscribeStream(i, newStreamIndex);
-            updateQuickTypeText();
             refreshPlotsThread->changedChannel(i, newStreamIndex);
             QCPGraph *graph = ui->plot->graph(i);
             QVector<double> empty;
@@ -691,8 +692,11 @@ void plotWindow::channelChanged(int newChan)
 ///
 void plotWindow::errStateChanged(bool checked)
 {
-    ui->quickFBComboBox->setCurrentIndex(0);
-    ui->quickErrComboBox->setCurrentIndex(0);
+    if (checked)
+        ui->quickFBComboBox->setCurrentIndex(0);
+    else
+        ui->quickErrComboBox->setCurrentIndex(0);
+
     QCheckBox *box = static_cast<QCheckBox *>(sender());
     for (int i=0; i<checkers.size(); i++) {
         if (checkers[i] == box) {

--- a/plotwindow.cpp
+++ b/plotwindow.cpp
@@ -70,7 +70,6 @@ plotWindow::plotWindow(zmq::context_t *context_in, options *opt, QWidget *parent
     chansocket = new zmq::socket_t(*zmqcontext, ZMQ_PUB);
     try {
         chansocket->bind(CHANSUBPORT);
-        std::cout << "chansocket publisher connected" << std::endl;
     } catch (zmq::error_t) {
         delete chansocket;
         chansocket = NULL;

--- a/plotwindow.cpp
+++ b/plotwindow.cpp
@@ -60,9 +60,8 @@ plotWindow::plotWindow(zmq::context_t *context_in, options *opt, QWidget *parent
     ms_per_sample(1),
     zmqcontext(context_in)
 {
-    // TODO: figure out how many rows and columns are in the actual data.
-    // Unlike matter, we can't just ask the client object. Has to go in packet
-    // headers or...? Oh! It could be a command-line argument.
+    // How many rows and columns are in the actual data:
+    // set via a command-line argument.
     nrows = opt->rows;
     ncols = opt->cols;
 
@@ -137,6 +136,14 @@ plotWindow::plotWindow(zmq::context_t *context_in, options *opt, QWidget *parent
     vp->insertItem(AXIS_POLICY_AUTO, "X range auto");
     vp->insertItem(AXIS_POLICY_EXPANDING, "X range expands");
     vp->insertItem(AXIS_POLICY_FIXED, "X range fixed");
+
+    // Is this an err/FB (TDM) system?
+    if (! opt->tdm) {
+        ui->quickErrComboBox->hide();
+        ui->quickErrLabel->hide();
+        ui->quickFBLabel->setText("Quick select Chan");
+        ui->actionErr_vs_FB->setDisabled(true);
+    }
 
     // Signal-slot connections
     connect(ui->quickChanEdit, SIGNAL(textChanged()),

--- a/plotwindow.cpp
+++ b/plotwindow.cpp
@@ -1056,13 +1056,16 @@ void plotWindow::plotTypeChanged(QAction *action)
             box->setPrefix("Ch ");
             checkers[i]->setChecked(false);
         }
+        for (int i=0; i<checkers.size(); i++) {
+            checkers[i]->setEnabled(false);
+        }
         ui->quickErrComboBox->setCurrentIndex(0);
         ui->quickErrComboBox->setEnabled(false);
         updateQuickTypeText();
     } else {
-//        for (int i=0; i<spinners.size(); i++) {
-//            QSpinBox *box = spinners[i];
-//        }
+        for (int i=0; i<checkers.size(); i++) {
+            checkers[i]->setEnabled(hasErr);
+        }
         ui->quickErrComboBox->setEnabled(hasErr);
     }
 

--- a/plotwindow.cpp
+++ b/plotwindow.cpp
@@ -1268,3 +1268,8 @@ void plotWindow::savePlot()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+
+void plotWindow::terminate() {
+    std::cout << "We are terminating the plot window" << std::endl;
+    close();
+}

--- a/plotwindow.h
+++ b/plotwindow.h
@@ -124,8 +124,10 @@ private:
     const static int NUM_TRACES=8;        ///< How many plot curves have their own channel selector
     QVector<QSpinBox *> spinners;         ///< The spin boxes that control which channels are plotted
     QVector<QCheckBox *> checkers;        ///< The check boxes that control which traces are error traces
-    QVector<int> quickSelectErrChan1;     ///< The lowest channel # signified by each comboBox range
-    QVector<int> quickSelectErrChan2;     ///< The highest channel # signified by each comboBox range
+    QVector<int> quickSelectChanMin;      ///< The lowest channel # signified by each comboBox range
+    QVector<int> quickSelectChanMax;      ///< The highest channel # signified by each comboBox range
+    QVector<QString> quickSelectFBTexts;  ///< The text signified by each comboBox range
+    QVector<QString> quickSelectErrTexts; ///< The text signified by each comboBox range
     QVector<int> streamIndex;             ///< The data stream index that selectedChannel corresponds to
     QActionGroup plotMenuActionGroup;     ///< Object that keeps plot type choices exclusive.
     QActionGroup analysisMenuActionGroup; ///< Object that keeps analysis choices exclusive.

--- a/plotwindow.h
+++ b/plotwindow.h
@@ -176,6 +176,7 @@ private slots:
     void yaxisUnitsChanged(QAction *action);
     void axisDoubleClicked(QCPAxis*,QCPAxis::SelectablePart,QMouseEvent*);
     void savePlot(void);
+    void terminate(void);
 };
 
 #endif // PLOTWINDOW_H

--- a/plotwindow.h
+++ b/plotwindow.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <QAction>
 #include <QActionGroup>
+#include <QCheckBox>
 #include <QColor>
 #include <QSettings>
 #include <QString>
@@ -95,7 +96,7 @@ public:
     explicit plotWindow(zmq::context_t *zmqcontext, options *opt, QWidget *parent = 0);
     ~plotWindow();
 
-    int chan2trace(int channum);
+    int streamnum2trace(int streamnum);
 
     refreshPlots *refreshPlotsThread;    ///< Thread to periodically update traces.
 
@@ -122,9 +123,10 @@ private:
     Ui::plotWindow *ui;                   ///< The underlying GUI form built in Qt Designer
     const static int NUM_TRACES=8;        ///< How many plot curves have their own channel selector
     QVector<QSpinBox *> spinners;         ///< The spin boxes that control which channels are plotted
+    QVector<QCheckBox *> checkers;        ///< The check boxes that control which traces are error traces
     QVector<int> quickSelectErrChan1;     ///< The lowest channel # signified by each comboBox range
     QVector<int> quickSelectErrChan2;     ///< The highest channel # signified by each comboBox range
-    QVector<int> selectedChannel;         ///< The channel number currently chosen in each spin box
+    QVector<int> streamIndex;             ///< The data stream index that selectedChannel corresponds to
     QActionGroup plotMenuActionGroup;     ///< Object that keeps plot type choices exclusive.
     QActionGroup analysisMenuActionGroup; ///< Object that keeps analysis choices exclusive.
     QActionGroup axisMenuActionGroup;     ///< Object that keeps axis choices exclusive.
@@ -139,12 +141,14 @@ private:
     double ms_per_sample;                 ///< Scaling from sample # to ms.
     bool preferVisibleMinMaxRange;        ///< Whether user wants min/max/range boxes visible
     bool preferYaxisRawUnits;             ///< Whether user wants raw units on y axis
+    bool hasErr;                          ///< Whether this source has error/FB channels
     zmq::context_t *zmqcontext;
     zmq::socket_t *chansocket;
 
     void startRefresh();
     void rescalePlots(QCPGraph *);
     void closeEvent(QCloseEvent *);
+    void subscribeStream(int tracenum, int newStreamIndex);
 
 private slots:
     void updateSpinners(void);
@@ -152,6 +156,7 @@ private slots:
     void updateQuickTypeFromFB(int);
     void updateQuickTypeText();
     void channelChanged(int);
+    void errStateChanged(bool);
     void pausePressed(bool);
     void yAxisLog(bool);
     void xAxisLog(bool);

--- a/version.h
+++ b/version.h
@@ -3,11 +3,12 @@
 
 #ifndef VERSION_MAJOR
 #define VERSION_MAJOR 0       ///< Major version #
-#define VERSION_MINOR 0       ///< Minor version #
-#define VERSION_REALLYMINOR 3 ///< Version release #
+#define VERSION_MINOR 1       ///< Minor version #
+#define VERSION_REALLYMINOR 0 ///< Version release #
 #endif
 /*
 
+  0.1.0 2018-10 Joe Fowler. Handle TDM/non-TDM separately via command-line args.
   0.0.3 2018-07 Joe Fowler. Fix double-free crashes.
   0.0.2 2018-07 Joe Fowler. Remove unneeded code left from matter.
   0.0.1 2018-07 Joe Fowler. Working towards Dastard 0.1


### PR DESCRIPTION
Use command-line arguments to set number of rows and columns and whether this is a TDM system.

I think there are still minor annoyances in how GUI elements interact, so maybe wait to pull until I fix those. Fixes #19.