### PR TITLE
Memory leak: partially fixed

### DIFF
--- a/datasubscriber.h
+++ b/datasubscriber.h
@@ -47,8 +47,6 @@ private:
     refreshPlots *plotManager; ///< Where we send data for plotting
     zmq::context_t *zmqcontext;
     zmq::socket_t *subscriber;
-    zmq::socket_t *killsocket;
-    zmq::socket_t *chansocket;
     std::string tcpdatasource;
 
     void subscribeChannel(int channum);

--- a/microscope.h
+++ b/microscope.h
@@ -6,7 +6,7 @@
 #define KILLPORT    "inproc://killthreads" ///< Port for the main thread to kill worker threads
 #define CHANSUBPORT "inproc://chansubscriptions" ///< Port for plotter to say which channels are needed
 
-static bool approx_equal(double a, double b, double reltol) {
+inline bool approx_equal(double a, double b, double reltol) {
     return fabs(a-b) < 0.5*(fabs(a)+fabs(b))*reltol;
 }
 

--- a/microscope.pro
+++ b/microscope.pro
@@ -14,8 +14,8 @@ CONFIG += qt thread
 
 LIBS += -lpthread -lfftw3 -lzmq # -lpthread -lX11 -lm -lXext -ldl -lfftw3 -lzmq
 QMAKE_CXXFLAGS += -std=c++0x
-QMAKE_CFLAGS_RELEASE += -O3
-QMAKE_CXXFLAGS_RELEASE += -O3
+QMAKE_CFLAGS_RELEASE += -O3 -g
+QMAKE_CXXFLAGS_RELEASE += -O3 -g
 QMAKE_CFLAGS_DEBUG += -O0
 QMAKE_CXXFLAGS_DEBUG += -O0
 

--- a/plotwindow.cpp
+++ b/plotwindow.cpp
@@ -638,8 +638,9 @@ void plotWindow::subscribeStream(int tracenum, int newStreamIndex) {
 
     // Signal to dataSubscriber
     if (newStreamIndex >= 0) {
-        char text[50];
-        snprintf(text, 50, "add %d", newStreamIndex);
+        char text[10];
+        // terminate message with space b/c of ZMQ message trickery
+        snprintf(text, 10, "add %d ", newStreamIndex);
         zmq::message_t msg(text, strlen(text));
         chansocket->send(msg);
     }
@@ -652,8 +653,8 @@ void plotWindow::subscribeStream(int tracenum, int newStreamIndex) {
         }
     }
     if (oldStreamIndex >= 0) {
-        char text[50];
-        snprintf(text, 50, "rem %d", oldStreamIndex);
+        char text[10];
+        snprintf(text, 10, "rem %d ", oldStreamIndex);
         zmq::message_t msg(text, strlen(text));
         chansocket->send(msg);
     }

--- a/plotwindow.ui
+++ b/plotwindow.ui
@@ -696,7 +696,7 @@
   </connection>
   <connection>
    <sender>actionSave_plot</sender>
-   <signal>activated()</signal>
+   <signal>triggered()</signal>
    <receiver>plotWindow</receiver>
    <slot>savePlot()</slot>
    <hints>

--- a/pulsehistory.cpp
+++ b/pulsehistory.cpp
@@ -23,6 +23,10 @@ pulseHistory::pulseHistory(int capacity, FFTMaster *master) :
 
 }
 
+pulseHistory::~pulseHistory() {
+    clearAllData();
+}
+
 
 ///
 /// \brief Clear the stored queues of records, power spectra, and analysis.

--- a/pulsehistory.cpp
+++ b/pulsehistory.cpp
@@ -31,7 +31,7 @@ void pulseHistory::clearAllData() {
     pulse_rms.clear();
     pulse_time.clear();
 
-    const int RESERVE=32; // reserve space for this many values (can max averages be larger than this?)
+    const int RESERVE=32; // reserve space for this many values--a memory optimization tactic
     pulse_average.reserve(RESERVE);
     pulse_peak.reserve(RESERVE);
     pulse_rms.reserve(RESERVE);
@@ -44,7 +44,7 @@ void pulseHistory::clearAllData() {
 
 
 ///
-/// \brief Clear the stored queues of records and power spectra\.
+/// \brief Clear the stored queues of records and power spectra.
 ///
 void pulseHistory::clearQueue(int keep) {
     if (keep < 0)
@@ -70,8 +70,8 @@ void pulseHistory::clearSpectra(int keep) {
         keep = 0;
     lock.lock();
     while (spectra.size() > keep) {
-        QVector<double> *r = spectra.dequeue();
-        delete r;
+        QVector<double> *sp = spectra.dequeue();
+        delete sp;
     }
     lock.unlock();
     Q_ASSERT(spectra.size() <= keep);
@@ -141,14 +141,14 @@ pulseRecord *pulseHistory::meanRecord(int nAverage) {
         return nullptr;
     }
 
-    QVector<double> *mean = new QVector<double>(nsamples, 0.0);
+    pulseRecord *result = new pulseRecord(*last);
 
     int nused = 0;
     lock.lock();
     for (int i=0; (i<records.size() && i<nAverage); i++) {
         if (records[i]->nsamples <= nsamples) {
             for (int j=0; j<nsamples; j++)
-                (*mean)[j] += records[i]->data[j];
+                (result->data)[j] += records[i]->data[j];
             nused++;
         }
     }
@@ -156,11 +156,8 @@ pulseRecord *pulseHistory::meanRecord(int nAverage) {
 
     if (nused > 1) {
          for (int j=0; j<nsamples; j++)
-            (*mean)[j] /= nused;
+            (result->data)[j] /= nused;
     }
-    pulseRecord *result = new pulseRecord(*last);
-    result->data = *mean;
-    delete mean;
     return result;
 }
 

--- a/pulsehistory.h
+++ b/pulsehistory.h
@@ -19,6 +19,7 @@ class pulseHistory
 {
 public:
     pulseHistory(int capacity, FFTMaster *master);
+    ~pulseHistory();
 
     void insertRecord(pulseRecord *pr);
     void clearAllData();

--- a/pulsehistory.h
+++ b/pulsehistory.h
@@ -38,10 +38,12 @@ public:
     QVector<double> &baseline() {return pulse_baseline;}
 
 private:
-    int queueCapacity; ///< How long the records and spectra queues should be.
-    int nsamples;      ///< How many samples are in the currently stored records.
-    int nstored;       ///< How many records have been stored ever.
-    bool doDFT;        ///< Whether we are actively doing DFTs on each record.
+    int queueCapacity;   ///< How long the records and spectra queues should be.
+    int analysisHardCap; ///< How many analyzed values may be stored.
+    int analysisSoftCap; ///< How many analyzed values will be saved after hitting the hard cap.
+    int nsamples;        ///< How many samples are in the currently stored records.
+    int nstored;         ///< How many records have been stored ever.
+    bool doDFT;          ///< Whether we are actively doing DFTs on each record.
     QQueue<pulseRecord *> records;  ///< The last N pulse records.
     QQueue<QVector<double> *> spectra;  ///< The last N power spectra.
     FFTMaster *fftMaster;

--- a/refreshplots.cpp
+++ b/refreshplots.cpp
@@ -278,8 +278,11 @@ void refreshPlots::refreshSpectrumPlots()
 
 
 ////////////////////////////////////////////////////////////////////////////////////
-/// \brief Called by the run loop once to draw standard (non-spectrum) plots
+/// \brief Called by the run loop once to draw timeseries plots
 ///
+/// Depend on QCustomPlot's addDataToPlot feature. This means infinite points can be
+/// added to the plot, even if our stored memory in pulseHistory is only 20k deep. But
+/// if you switch which analyzed values to plot, only those in pulseHistory get plotted.
 void refreshPlots::refreshTimeseriesPlots()
 {
     for (int trace=0; trace<channels.size(); trace++) {
@@ -396,6 +399,7 @@ void refreshPlots::changedChannel(int traceNumber, int channelNumber)
     if (traceNumber >= channels.size())
         return;
     channels[traceNumber] = channelNumber;
+    lastSerial[traceNumber] = -1;
     pulseHistories[traceNumber]->clearAllData();
 
     //    scratch[traceNumber].clear();
@@ -470,7 +474,12 @@ void refreshPlots::setIsFFT(bool fft)
 ///
 void refreshPlots::setIsTimeseries(bool ts)
 {
+    if (isTimeseries == ts)
+        return;
     isTimeseries = ts;
+    for (int tracenum=0; tracenum < channels.size(); tracenum++) {
+        lastSerial[tracenum] = -1;
+    }
 }
 
 
@@ -486,7 +495,7 @@ void refreshPlots::setAnalysisType(enum analysisFields newType)
 
     analysisType = newType;
     for (int tracenum=0; tracenum < channels.size(); tracenum++) {
-        lastSerial[tracenum] = 0;
+        lastSerial[tracenum] = -1;
 
 //        scratch[tracenum].clear();
 //        histograms[tracenum]->clear();

--- a/refreshplots.cpp
+++ b/refreshplots.cpp
@@ -226,7 +226,7 @@ void refreshPlots::refreshStandardPlots()
 
 
 ////////////////////////////////////////////////////////////////////////////////////
-/// \brief Called by the run loop once to draw standard (non-spectrum) plots
+/// \brief Called by the run loop once to draw spectrum plots
 ///
 void refreshPlots::refreshSpectrumPlots()
 {

--- a/refreshplots.cpp
+++ b/refreshplots.cpp
@@ -93,8 +93,7 @@ refreshPlots::~refreshPlots()
 /// \param length
 ///
 void refreshPlots::receiveNewData(int tracenum, pulseRecord *pr) {
-    if (tracenum < 0 || tracenum >= pulseHistories.size())
-        return;
+    Q_ASSERT (tracenum >= 0 && tracenum < pulseHistories.size());
     struct timeval now;
     gettimeofday(&now, nullptr);
     pr->dtime = now.tv_sec-time_zero.tv_sec + now.tv_usec*1e-6;

--- a/version.h
+++ b/version.h
@@ -4,10 +4,11 @@
 #ifndef VERSION_MAJOR
 #define VERSION_MAJOR 0       ///< Major version #
 #define VERSION_MINOR 1       ///< Minor version #
-#define VERSION_REALLYMINOR 0 ///< Version release #
+#define VERSION_REALLYMINOR 1 ///< Version release #
 #endif
 /*
 
+  0.1.1 2019-06 Joe Fowler. Finite amount of analysis stored; memory leaks attacked.
   0.1.0 2018-10 Joe Fowler. Handle TDM/non-TDM separately via command-line args.
   0.0.3 2018-07 Joe Fowler. Fix double-free crashes.
   0.0.2 2018-07 Joe Fowler. Remove unneeded code left from matter.


### PR DESCRIPTION
This doesn't fix a memory leak exactly, but it stops deliberately storing an unbounded amount of analyzed pulse values. Instead, there's a "hard cap" of 20k values (per channel, per analysis type) and a soft cap of 16k values. Each time the hard cap is hit, then the oldest values will be removed until the soft cap is reached. Having a big difference between the two caps means we are not copying long memory sections very often.

Addresses #26 but is not likely to solve it. For that, I'll need to run valgrind on Linux.