### PR TITLE
Fix ZMQ deprecations by checking for ZMQ_CPP11 preprocessor token

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Microscope (https://github.com/usnistgov/microscope) is a tool to plot microcalorimeter
 pulses in an oscilloscope style, with traces from up to 8 separate channels. Plots
-can include 
+can include
 
 * Time-series plots of triggered records
 * Power spectral densities of triggered records
@@ -18,21 +18,21 @@ To proceed, you will need to have installed:
 * zmq including zmq.hpp (the C++ binding)
 * Qt5 (or Qt4) development libraries (we encourage Qt5)
 
-On an Ubuntu 16.04 system, this can be accomplished by a command along these lines:
+On an Ubuntu 18.04 system, this can be accomplished by a command along these lines:
 
 ```
-sudo apt-get install gcc make git qt5-default qt5-qmake libczmq-dev libzmqpp-dev libfftw3-dev
+sudo apt-get install gcc make git qt5-default qt5-qmake libzmq3-dev libfftw3-dev
 # If you really need qt4 for other reasons, then replace the above with:
-# sudo apt-get install gcc make git qt4-default qt4-qmake libczmq-dev libzmqpp-dev libfftw3-dev
-# And if you want to work on the program, you probably also want:
+# sudo apt-get install gcc make git qt4-default qt4-qmake libzmq3-dev libfftw3-dev
+
+# If you want to work on the program, you probably also want:
 sudo apt-get install qtcreator qtchooser
 ```
 
-On MacPorts, you need something like (probably not all 4 of the following ZMQ ports are
-required, but this is what I have installed at the moment; you can experiment with a
-shorter list):
+On MacPorts, you need something like the following:
 ```
-sudo port install qt5 qt5-base gcc9 gmake git cppzmq czmq zmq zmqpp fftw-3
+sudo port install qt5 qt5-base gcc9 gmake git cppzmq zmq fftw-3
+# If you want to work on the program, you probably also want:
 sudo port install qt5-qtcreator
 ```
 
@@ -54,7 +54,7 @@ generated in the past by the Qt4 version of `qmake` step before running the Qt5 
 
 #### Installation
 
-If one of those methods works, then you need to _install_ microscope somewhere in your 
+If one of those methods works, then you need to _install_ microscope somewhere in your
 path, so that [dastard-commander](https://github.com/usnistgov/dastard-commander)
 can start it automatically. We have not yet created a `make install` target, because
 `qmake` is super-confusing, so you have two slightly less convenient choices.
@@ -78,7 +78,7 @@ that replaces it by the same name in the same directory:
 sudo ln -s /home/pcuser/microscope/microscope /usr/local/bin/
 ```
 
-**Check that it worked** Now change to an arbitrary directory and make sure you can 
+**Check that it worked** Now change to an arbitrary directory and make sure you can
 run the program:
 
 ```

--- a/datasubscriber.cpp
+++ b/datasubscriber.cpp
@@ -133,12 +133,20 @@ void dataSubscriber::process() {
 
         if (pollitems[0].revents & ZMQ_POLLIN) {
             // killsocket received a message. Any message there means DIE.
+            #if CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
+            killsocket->recv(update);
+            #else
             killsocket->recv(&update);
+            #endif
             break;
         }
         if (pollitems[1].revents & ZMQ_POLLIN) {
             // chansocket received a message.
+            #if CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
+            chansocket->recv(update);
+            #else
             chansocket->recv(&update);
+            #endif
             parseChannelMessage(update);
             continue;
         }
@@ -148,12 +156,20 @@ void dataSubscriber::process() {
         }
 
         // Receive a 2-part message
+        #if CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
+        subscriber->recv(header);
+        #else
         subscriber->recv(&header);
+        #endif
         if (!header.more()) {
             std::cerr << "Received an unexpected 1-part message" << std::endl;
             continue;
         }
+        #if CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
+        subscriber->recv(pulsedata);
+        #else
         subscriber->recv(&pulsedata);
+        #endif
 
         pulseRecord *pr = new pulseRecord(header, pulsedata);
         // std::cout << "Received message of size " << header.size() << "+" << pulsedata.size();
@@ -184,5 +200,3 @@ void dataSubscriber::process() {
 void dataSubscriber::wait(unsigned long time) {
     myThread->wait(time);
 }
-
-

--- a/main.cpp
+++ b/main.cpp
@@ -123,12 +123,14 @@ int main(int argc, char *argv[])
     int app_return_val = a.exec();
 
     const char quit[] = "Quit";
-    killsocket->send(quit, strlen(quit));
     // The following will eliminate a certain deprecation message in zmqpp >= version 4.3.1.
-    // But it won't compile at (for example) version 4.1.1.
-    // Someday, we'll have to figure this out.  -Joe Fowler. March 7, 2020.
-    //    zmq::const_buffer Qmsg = zmq::const_buffer(quit, strlen(quit));
-    //    killsocket->send(Qmsg);
+    // But it won't compile at (for example) version 4.1.1, hence the #if/#else/#endif.
+#if CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
+    zmq::const_buffer Qmsg = zmq::const_buffer(quit, strlen(quit));
+    killsocket->send(Qmsg);
+#else
+    killsocket->send(quit, strlen(quit));
+#endif
 
     sub->wait(1000);
     delete sub;

--- a/plotwindow.cpp
+++ b/plotwindow.cpp
@@ -641,8 +641,13 @@ void plotWindow::subscribeStream(int tracenum, int newStreamIndex) {
         char text[20];
         // terminate message with space b/c of ZMQ message trickery
         snprintf(text, 20, "add %d ", newStreamIndex);
-        zmq::message_t msg(text, strlen(text));
-        chansocket->send(msg);
+        #if CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
+            zmq::const_buffer Qmsg = zmq::const_buffer(text, strlen(text));
+            chansocket->send(Qmsg);
+        #else
+            zmq::message_t msg(text, strlen(text));
+            chansocket->send(msg);
+        #endif
     }
 
     // Now unsubscribe the previous channel, first checking that it's not
@@ -655,8 +660,13 @@ void plotWindow::subscribeStream(int tracenum, int newStreamIndex) {
     if (oldStreamIndex >= 0) {
         char text[20];
         snprintf(text, 20, "rem %d ", oldStreamIndex);
-        zmq::message_t msg(text, strlen(text));
-        chansocket->send(msg);
+        #if CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 3, 1)
+            zmq::const_buffer Qmsg = zmq::const_buffer(text, strlen(text));
+            chansocket->send(Qmsg);
+        #else
+            zmq::message_t msg(text, strlen(text));
+            chansocket->send(msg);
+        #endif
     }
 }
 


### PR DESCRIPTION
Fixes #32. Annoying, but it is nice to be rid of the deprecation warnings in newer ZMQ versions.