### PR TITLE
Fix error/FB ordering problem

### DIFF
--- a/plotwindow.cpp
+++ b/plotwindow.cpp
@@ -260,16 +260,16 @@ void plotWindow::buildNameIndexTables(const options *opt) {
     int index=0;
     foreach(channelGroup cg, opt->chanGroups) {
         for (int cnum=cg.firstchan; cnum<cg.firstchan+cg.nchan; cnum++) {
-            QString name = QString("Ch %1").arg(cnum);
-            channelNames.append(name);
-            channelName2Index[name] = index;
-            index++;
             if (hasErr) {
                 QString name = QString("Err %1").arg(cnum);
                 channelNames.append(name);
                 channelName2Index[name] = index;
                 index++;
             }
+            QString name = QString("Ch %1").arg(cnum);
+            channelNames.append(name);
+            channelName2Index[name] = index;
+            index++;
         }
     }
     // std::cout << "Debug:\n";


### PR DESCRIPTION
Introduced a bug in cc367c9. Fixes #38.

Tested on Horton seems to fix the problem of error and feedback being flipped when chosing from the quick select menu.