### PR TITLE
Workaround error in Ubuntu's ZMQCPP versioning

### DIFF
--- a/datasubscriber.h
+++ b/datasubscriber.h
@@ -58,7 +58,17 @@ private:
 
 // The API for zmq::socket_t changes in version 4.7.0+ but only if you're using C++11 or later.
 #if (defined(ZMQ_CPP11) && (CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 7, 0)))
-#define USE_NEW_SOCKET_SET_API
+    #define USE_NEW_SOCKET_SET_API
+
+    // ...but there's a stupendously annoying BUG in the Ubuntu 20.04 version. It packages an
+    // incomplete version of ZMQCPP that it _calls_ 4.7.0 but that does not contain the full 4.7.0 API.
+    // Grrr. As a workaround, let's simply say that any Linux using ZMQCPP version exactly =4.7.0 will
+    // use the older API.
+    #ifdef __linux__
+        #if (CPPZMQ_VERSION == ZMQ_MAKE_VERSION(4, 7, 0))
+            #undef USE_NEW_SOCKET_SET_API
+        #endif
+    #endif
 #endif
 
 #endif // DATASUBSCRIBER_H


### PR DESCRIPTION
Fixes #46. Ubuntu 20.04 packages a ZMQCPP from an untagged commit that incompletely implements the 4.7.0 API, but it calls that version 4.7.0. Not good! Assume that v 4.7.0 on any Linux does NOT use the new API.