### PR TITLE
Average the most recent N records as opposed to the oldest N records

### DIFF
--- a/demo/demo_noise.py
+++ b/demo/demo_noise.py
@@ -5,7 +5,6 @@ demo_pulses.py
 Generate pulse-like data to appear as ZMQ packets, in order to develop microscope.
 """
 
-import pylab as plt
 import numpy as np
 import zmq
 
@@ -34,7 +33,7 @@ while True:
 
     thisdata = np.asarray(10000+1000*channel + noise[:-2]+2*noise[1:-1]+noise[2:], dtype=np.uint16)
     header = pulseRecord[channel].packheader(thisdata)
-    print "chan %d message length %d" % (channel, len(thisdata))
+    print("chan %d message length %d" % (channel, len(thisdata)))
     socket.send(header, zmq.SNDMORE)
     socket.send(thisdata.data[:])
     time.sleep(0.1)

--- a/demo/demo_noisy_pulse.py
+++ b/demo/demo_noisy_pulse.py
@@ -5,7 +5,6 @@ demo_pulses.py
 Generate pulse-like data to appear as ZMQ packets, in order to develop microscope.
 """
 
-import pylab as plt
 import numpy as np
 import zmq
 
@@ -36,7 +35,7 @@ while True:
     channel = random.randrange(chanmin, chanmax+1)
     thisdata = np.asarray(messagedata[channel] + np.random.random_integers(-500, 500, size=samples), dtype=np.uint16)
     header = pulseRecord[channel].packheader(thisdata)
-    print "chan %d message length %d" % (channel, len(thisdata))
+    print("chan %d message length %d" % (channel, len(thisdata)))
     socket.send(header, zmq.SNDMORE)
     socket.send(thisdata.data[:])
     time.sleep(0.1)

--- a/demo/demo_pulses.py
+++ b/demo/demo_pulses.py
@@ -5,7 +5,6 @@ demo_pulses.py
 Generate pulse-like data to appear as ZMQ packets, in order to develop microscope.
 """
 
-import pylab as plt
 import numpy as np
 import zmq
 
@@ -36,7 +35,7 @@ while True:
     channel = random.randrange(1,21)
     thisdata = np.asarray(messagedata[channel], dtype=np.uint16)
     header = pulseRecord[channel].packheader(thisdata)
-    print "chan %d message length %d" % (channel, len(thisdata))
+    print("chan %d message length %d" % (channel, len(thisdata)))
     socket.send(header, zmq.SNDMORE)
     socket.send(thisdata.data[:])
     time.sleep(0.1)

--- a/pulsehistory.cpp
+++ b/pulsehistory.cpp
@@ -152,11 +152,11 @@ pulseRecord *pulseHistory::meanRecord(int nAverage) {
 
     int nused = 0;
     lock.lock();
-    int offset = records.size() - nAverage;
-    for (int i=0; ((i+offset)<records.size() && i<nAverage); i++) {
+    int start = std::max(records.size() - nAverage, 0);
+    for (int i=start; i<records.size(); i++) {
         if (records[i]->nsamples <= nsamples) {
             for (int j=0; j<nsamples; j++)
-                (result->data)[j] += records[i+offset]->data[j];
+                (result->data)[j] += records[i]->data[j];
             nused++;
         }
     }
@@ -187,11 +187,11 @@ QVector<double> *pulseHistory::meanPSD(int nAverage) {
 
     int nused = 0;
     lock.lock();
-    int offset = records.size() - nAverage;
-    for (int i=0; ((i+offset)<spectra.size() && i<nAverage); i++) {
+    int start = std::max(records.size() - nAverage,0);
+    for (int i=start; i<spectra.size(); i++) {
         if (spectra[i]->size() == nfreq) {
             for (int j=0; j<nfreq; j++)
-                mean_psd[j] += (*spectra[i+offset])[j];
+                mean_psd[j] += (*spectra[i])[j];
             nused++;
         }
     }

--- a/pulsehistory.cpp
+++ b/pulsehistory.cpp
@@ -139,7 +139,7 @@ QVector<double> *pulseHistory::newestPSD() const {
 
 
 ///
-/// \brief Compute and return the mean of all stored records.
+/// \brief Compute and return the mean of the last 'nAverage' stored records.
 /// \return
 ///
 pulseRecord *pulseHistory::meanRecord(int nAverage) {
@@ -152,10 +152,11 @@ pulseRecord *pulseHistory::meanRecord(int nAverage) {
 
     int nused = 0;
     lock.lock();
-    for (int i=0; (i<records.size() && i<nAverage); i++) {
+    int offset = records.size() - nAverage;
+    for (int i=0; ((i+offset)<records.size() && i<nAverage); i++) {
         if (records[i]->nsamples <= nsamples) {
             for (int j=0; j<nsamples; j++)
-                (result->data)[j] += records[i]->data[j];
+                (result->data)[j] += records[i+offset]->data[j];
             nused++;
         }
     }
@@ -170,7 +171,7 @@ pulseRecord *pulseHistory::meanRecord(int nAverage) {
 
 
 ///
-/// \brief pulseHistory::meanPSD
+/// \brief Compute and return the mean of the last 'nAverage' stored PSDs
 /// \return
 ///
 QVector<double> *pulseHistory::meanPSD(int nAverage) {
@@ -186,10 +187,11 @@ QVector<double> *pulseHistory::meanPSD(int nAverage) {
 
     int nused = 0;
     lock.lock();
-    for (int i=0; (i<spectra.size() && i<nAverage); i++) {
+    int offset = records.size() - nAverage;
+    for (int i=0; ((i+offset)<spectra.size() && i<nAverage); i++) {
         if (spectra[i]->size() == nfreq) {
             for (int j=0; j<nfreq; j++)
-                mean_psd[j] += (*spectra[i])[j];
+                mean_psd[j] += (*spectra[i+offset])[j];
             nused++;
         }
     }

--- a/refreshplots.cpp
+++ b/refreshplots.cpp
@@ -35,7 +35,7 @@ refreshPlots::refreshPlots(int msec_period) :
     isFFT(false),
 //    isHistogram(false),
     averaging(false),
-    nAverage(16), // matches the initial value of spinBox_nAverage in QtDesigner
+    nAverage(1), // matches the initial value of spinBox_nAverage in QtDesigner
     analysisType(ANALYSIS_PULSE_RMS)
 {
     // Fill the list of channels to be plotted with the no-plot indicator.

--- a/version.h
+++ b/version.h
@@ -4,10 +4,10 @@
 #ifndef VERSION_MAJOR
 #define VERSION_MAJOR 0       ///< Major version #
 #define VERSION_MINOR 1       ///< Minor version #
-#define VERSION_REALLYMINOR 7 ///< Version release #
+#define VERSION_REALLYMINOR 8 ///< Version release #
 #endif
 /*
-
+  0.1.8 2024-07 Christopher Rooney. Average the most recent records instead of the oldest, and other bug fixes for averaging.
   0.1.7 2024-07 Joe Fowler. Make microscope -h return 0, not error.
   0.1.6 2023-01 Joe Fowler. Include zmq.hpp directly to ensure latest cppzmq.
   0.1.5 2022-03 Joe Fowler. Fix error in use of new API in cppzmq 4.7.0+.


### PR DESCRIPTION
I was experiencing odd behavior in Microscope, e.g. I turned the feedback off and Microscope still showed changing traces if averaging was enabled. I was able to track it down to the averaging functions, which appear to be averaging the oldest N records in the queue, which is 128 records long.

Please double check my math to make sure there won't be any out of bounds pointer reads.

These changes were briefly tested to work on Velma.