### PR TITLE
Fix FFT and PSD normalization

### DIFF
--- a/fftcomputer.cpp
+++ b/fftcomputer.cpp
@@ -95,9 +95,9 @@ void FFTComputer::prepare(int length_in) {
 
     // When using a window function, the amount of power in the signal is reduced.
     // To compensate for this, the average(window[i]^2) should be scaled to 1.
-    const double meansq = sumsq / length;
+    const double rtmeansq = sqrt(sumsq / length);
     for (int i=0; i<length; i++) {
-        window[i] /= meansq;
+        window[i] /= rtmeansq;
     }
 }
 

--- a/pulsehistory.cpp
+++ b/pulsehistory.cpp
@@ -105,8 +105,8 @@ void pulseHistory::setDoDFT(bool dft) {
         lock.lock();
         for (int i=0; i<n; i++) {
             QVector<double> *psd = new QVector<double>;
-            const double sampleRate = 1.0;
-            fftMaster->computePSD(records[i]->data, *psd, sampleRate, WINDOW, previous_mean);
+            // const double sampleRate = 1.0;
+            fftMaster->computePSD(records[i]->data, *psd, 1/records[i]->sampletime, WINDOW, previous_mean);
             spectra.append(psd);
         }
         lock.unlock();
@@ -233,7 +233,7 @@ void pulseHistory::insertRecord(pulseRecord *pr) {
         clearSpectra(queueCapacity-1);
         const bool WINDOW=true; // always use Hann windowing
         QVector<double> *psd = new QVector<double>();
-        fftMaster->computePSD(pr->data, *psd, 1.0, WINDOW, previous_mean);
+        fftMaster->computePSD(pr->data, *psd, 1/pr->sampletime, WINDOW, previous_mean);
         lock.lock();
         spectra.enqueue(psd);
         lock.unlock();


### PR DESCRIPTION
in #53 I started working on figuring out why I'm experiencing some strange values for the amplitude of the PSD. I think I've tracked down the two issues with normalization, and so I've fixed them in the two commits here. After these two commits, for a given time series Microscope and scipy.signal.periodogram (which is what Hannes and I have been using for offline data processing) produce the same spectrum. 