### PR TITLE
Improve log scale axis ticks; fix log scale bug #55

### DIFF
--- a/demo/message_definition.py
+++ b/demo/message_definition.py
@@ -12,16 +12,16 @@ class DastardPulse(object):
 
     def packheader(self, data, trig_time = None, serialnumber = None):
         if data.dtype in (np.int64, np.uint64):
-            nptype, wordcode, size = "Q", 7, 8
+            wordcode, size = 7, 8
         elif data.dtype in (np.int32, np.uint32):
-            nptype, wordcode, size = "L", 5, 4
+            wordcode, size = 5, 4
         elif data.dtype == np.uint16:
-            nptype, wordcode, size = "H", 3, 2
+            wordcode, size = 3, 2
         elif data.dtype == np.int16:
             wordcode = 2
-            size=2
+            size = 2
         elif data.dtype in (np.int8, np.uint8):
-            nptype, wordcode, size = "B", 1, 1
+            wordcode, size = 1, 1
         else:
             raise ValueError("Cannot handle numpy type %s"%data.dtype)
 

--- a/demo/message_definition.py
+++ b/demo/message_definition.py
@@ -15,8 +15,11 @@ class DastardPulse(object):
             nptype, wordcode, size = "Q", 7, 8
         elif data.dtype in (np.int32, np.uint32):
             nptype, wordcode, size = "L", 5, 4
-        elif data.dtype in (np.int16, np.uint16):
+        elif data.dtype == np.uint16:
             nptype, wordcode, size = "H", 3, 2
+        elif data.dtype == np.int16:
+            wordcode = 2
+            size=2
         elif data.dtype in (np.int8, np.uint8):
             nptype, wordcode, size = "B", 1, 1
         else:

--- a/plotwindow.cpp
+++ b/plotwindow.cpp
@@ -791,14 +791,10 @@ void plotWindow::pausePressed(bool pause_state)
 ///
 void plotWindow::xAxisLog(bool checked)
 {
-
-    //std::cout << "number format was: " << ui->plot->xAxis->numberFormat().toStdString() << "precision was" << ui->plot->xAxis->numberPrecision() << std::endl;
     QCPAxis::ScaleType st;
-    // QSharedPointer<QCPAxisTicker> ticker;
     if (checked) 
     {
         st = QCPAxis::stLogarithmic;
-        // ticker = QSharedPointer<QCPAxisTicker>(new QCPAxisTickerLog);
         ui->plot->xAxis->setTicker(QSharedPointer<QCPAxisTickerLog>(new QCPAxisTickerLog));
         ui->plot->xAxis->setNumberPrecision(0);
         ui->plot->xAxis->setNumberFormat("eb");
@@ -806,14 +802,12 @@ void plotWindow::xAxisLog(bool checked)
     else 
     {
         st= QCPAxis::stLinear;
-        // ticker = QSharedPointer<QCPAxisTicker>(new QCPAxisTickerFixed);
         ui->plot->xAxis->setTicker(QSharedPointer<QCPAxisTicker>(new QCPAxisTicker));
         ui->plot->xAxis->setNumberFormat("gb");
         ui->plot->xAxis->setNumberPrecision(6);
  
     }
     ui->plot->xAxis->setScaleType(st);
-    // ui->plot->xAxis->setTicker(ticker);
     
 }
 

--- a/plotwindow.cpp
+++ b/plotwindow.cpp
@@ -791,12 +791,30 @@ void plotWindow::pausePressed(bool pause_state)
 ///
 void plotWindow::xAxisLog(bool checked)
 {
+
+    //std::cout << "number format was: " << ui->plot->xAxis->numberFormat().toStdString() << "precision was" << ui->plot->xAxis->numberPrecision() << std::endl;
     QCPAxis::ScaleType st;
-    if (checked)
+    // QSharedPointer<QCPAxisTicker> ticker;
+    if (checked) 
+    {
         st = QCPAxis::stLogarithmic;
-    else
+        // ticker = QSharedPointer<QCPAxisTicker>(new QCPAxisTickerLog);
+        ui->plot->xAxis->setTicker(QSharedPointer<QCPAxisTickerLog>(new QCPAxisTickerLog));
+        ui->plot->xAxis->setNumberPrecision(0);
+        ui->plot->xAxis->setNumberFormat("eb");
+    }
+    else 
+    {
         st= QCPAxis::stLinear;
+        // ticker = QSharedPointer<QCPAxisTicker>(new QCPAxisTickerFixed);
+        ui->plot->xAxis->setTicker(QSharedPointer<QCPAxisTicker>(new QCPAxisTicker));
+        ui->plot->xAxis->setNumberFormat("gb");
+        ui->plot->xAxis->setNumberPrecision(6);
+ 
+    }
     ui->plot->xAxis->setScaleType(st);
+    // ui->plot->xAxis->setTicker(ticker);
+    
 }
 
 
@@ -809,9 +827,29 @@ void plotWindow::yAxisLog(bool checked)
 {
     QCPAxis::ScaleType st;
     if (checked)
+    {
+        QCPRange range = ui->plot->yAxis->range();
+        if(range.lower <= 0)
+        {
+            range.lower=0.1;
+        }
+        if(range.upper <= 0.1)
+        {
+            range.upper = 0.2;
+        }
+        ui->plot->yAxis->setRange(range);
         st = QCPAxis::stLogarithmic;
+        ui->plot->yAxis->setTicker(QSharedPointer<QCPAxisTickerLog>(new QCPAxisTickerLog));
+        ui->plot->yAxis->setNumberPrecision(0);
+        ui->plot->yAxis->setNumberFormat("eb");
+    }
     else
+    {
         st= QCPAxis::stLinear;
+        ui->plot->yAxis->setTicker(QSharedPointer<QCPAxisTicker>(new QCPAxisTicker));
+        ui->plot->yAxis->setNumberFormat("gb");
+        ui->plot->yAxis->setNumberPrecision(6);
+    }
     ui->plot->yAxis->setScaleType(st);
 }
 


### PR DESCRIPTION
When switching between log and linear scaling, update the axis ticker to match the axis scale type and set labels to scientific notation. Also check that the axis bounds are positive so that the log scale doesn't get stuck negative (See the [documentation of rescaleAxes in QCustomPlot](https://www.qcustomplot.com/documentation/classQCPAbstractPlottable.html#a1491c4a606bccd2d09e65e11b79eb882) for more details)

Also includes a minor tweak to the python demo scripts to allow negative numbers for testing.

Should close #55.
![Screenshot_2024-12-10_15-40-48](https://github.com/user-attachments/assets/8efbee49-8c32-4e11-ac27-a826337415ad)

Maybe check my code because every time the log scale box is checked or unchecked I make a new Axis Ticker and don't ever delete it. the Q Shared Pointer might take care of deleting it for me but I can never tell.
